### PR TITLE
fix HTTP DELETE

### DIFF
--- a/src/synapse/dataProvider.js
+++ b/src/synapse/dataProvider.js
@@ -207,13 +207,14 @@ const dataProvider = {
     const res = resourceMap[resource];
     const homeserver_url = "https://" + homeserver + res.path;
     return Promise.all(
-      params.ids.map(id => jsonClient(`${homeserver_url}/${id}`), {
-        method: "DELETE",
-        body: JSON.stringify(params.data, filterNullValues),
-      })
-    ).then(responses => ({
-      data: responses.map(({ json }) => json),
-    }));
+      params.ids.map(id => jsonClient(`${homeserver_url}/${id}`, {
+          method: "DELETE",
+          body: JSON.stringify(params.data, filterNullValues),
+        },
+      ).then(responses => ({
+        data: responses.map(({ json }) => json),
+      })))
+    );
   },
 };
 


### PR DESCRIPTION
There seems to be a typo that causes the options to be blank by default.

It doesn't work nevertheless even with this change as at least according to https://github.com/matrix-org/synapse/blob/master/docs/admin_api/rooms.md there is no DELETE API.
I guess this should use https://github.com/matrix-org/synapse/blob/master/docs/admin_api/purge_room.md instead.