### PR TITLE
Add switch to login form for choosing well-know or given server address

### DIFF
--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -72,7 +72,7 @@ const LoginPage = ({ theme }) => {
   const setLocale = useSetLocale();
   const translate = useTranslate();
   const homeserver = localStorage.getItem("base_url");
-  const force_server = localStorage.getItem("force_server");
+  const force_server = localStorage.getItem("force_server") === "true";
 
   const renderInput = ({
     meta: { touched, error } = {},

--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -6,6 +6,7 @@ import {
   useLocale,
   useSetLocale,
   useTranslate,
+  BooleanInput,
 } from "react-admin";
 import { Field, Form } from "react-final-form";
 import {
@@ -71,6 +72,7 @@ const LoginPage = ({ theme }) => {
   const setLocale = useSetLocale();
   const translate = useTranslate();
   const homeserver = localStorage.getItem("base_url");
+  const force_server = localStorage.getItem("force_server");
 
   const renderInput = ({
     meta: { touched, error } = {},
@@ -117,7 +119,7 @@ const LoginPage = ({ theme }) => {
 
   return (
     <Form
-      initialValues={{ homeserver: homeserver }}
+      initialValues={{ homeserver: homeserver, force_server: force_server }}
       onSubmit={handleSubmit}
       validate={validate}
       render={({ handleSubmit }) => (
@@ -152,6 +154,14 @@ const LoginPage = ({ theme }) => {
                     name="homeserver"
                     component={renderInput}
                     label={translate("synapseadmin.auth.homeserver")}
+                    disabled={loading}
+                  />
+                </div>
+                  <div className={classes.input}>
+                  <BooleanInput
+                    autoFocus
+                    name="force_server"
+                    label={translate("synapseadmin.auth.force_server")}
                     disabled={loading}
                   />
                 </div>

--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -157,7 +157,7 @@ const LoginPage = ({ theme }) => {
                     disabled={loading}
                   />
                 </div>
-                  <div className={classes.input}>
+                <div className={classes.input}>
                   <BooleanInput
                     autoFocus
                     name="force_server"

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -6,6 +6,7 @@ export default {
     auth: {
       homeserver: "Heimserver",
       welcome: "Willkommen bei Synapse-admin",
+      force_server: "Homeserver-Adresse erzwingen",
     },
     users: {
       invalid_user_id:

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -6,6 +6,7 @@ export default {
     auth: {
       homeserver: "Homeserver",
       welcome: "Welcome to Synapse-admin",
+      force_server: "Force homeserver address",
     },
     users: {
       invalid_user_id:

--- a/src/synapse/authProvider.js
+++ b/src/synapse/authProvider.js
@@ -15,9 +15,17 @@ const stripTrailingSlash = str => {
   return str.endsWith("/") ? str.slice(0, -1) : str;
 };
 
+const getBaseUrl = (login_base_url, json_base_url, force_server) => {
+  if (force_server) {
+    return ensureHttpsForUrl(login_base_url);
+  } else {
+    return json_base_url;
+  }
+}
+
 const authProvider = {
   // called when the user attempts to log in
-  login: ({ homeserver, username, password }) => {
+  login: ({ homeserver, force_server, username, password }) => {
     console.log("login ");
     const options = {
       method: "POST",
@@ -34,11 +42,15 @@ const authProvider = {
       ensureHttpsForUrl(trimmed_url) + "/_matrix/client/r0/login";
 
     return fetchUtils.fetchJson(login_api_url, options).then(({ json }) => {
-      const normalized_base_url = stripTrailingSlash(
-        json.well_known["m.homeserver"].base_url
-      );
+      const normalized_base_url = stripTrailingSlash(getBaseUrl(
+        trimmed_url,
+        json.well_known["m.homeserver"].base_url,
+        force_server
+      ));
+
       localStorage.setItem("base_url", normalized_base_url);
       localStorage.setItem("home_server_url", json.home_server);
+      localStorage.setItem("force_server", force_server);
       localStorage.setItem("user_id", json.user_id);
       localStorage.setItem("access_token", json.access_token);
       localStorage.setItem("device_id", json.device_id);

--- a/src/synapse/authProvider.js
+++ b/src/synapse/authProvider.js
@@ -15,11 +15,11 @@ const stripTrailingSlash = str => {
   return str.endsWith("/") ? str.slice(0, -1) : str;
 };
 
-const getBaseUrl = (login_base_url, json_base_url, force_server) => {
-  if (force_server) {
-    return ensureHttpsForUrl(login_base_url);
+const getBaseUrl = (login_url, json, force_server) => {
+  if (force_server || typeof json.well_known === "undefined") {
+    return ensureHttpsForUrl(login_url);
   } else {
-    return json_base_url;
+    return json.well_known["m.homeserver"].base_url;
   }
 };
 
@@ -43,11 +43,7 @@ const authProvider = {
 
     return fetchUtils.fetchJson(login_api_url, options).then(({ json }) => {
       const normalized_base_url = stripTrailingSlash(
-        getBaseUrl(
-          trimmed_url,
-          json.well_known["m.homeserver"].base_url,
-          force_server
-        )
+        getBaseUrl(trimmed_url, json, force_server)
       );
 
       localStorage.setItem("base_url", normalized_base_url);

--- a/src/synapse/authProvider.js
+++ b/src/synapse/authProvider.js
@@ -42,11 +42,13 @@ const authProvider = {
       ensureHttpsForUrl(trimmed_url) + "/_matrix/client/r0/login";
 
     return fetchUtils.fetchJson(login_api_url, options).then(({ json }) => {
-      const normalized_base_url = stripTrailingSlash(getBaseUrl(
-        trimmed_url,
-        json.well_known["m.homeserver"].base_url,
-        force_server
-      ));
+      const normalized_base_url = stripTrailingSlash(
+        getBaseUrl(
+          trimmed_url,
+          json.well_known["m.homeserver"].base_url,
+          force_server
+        )
+      );
 
       localStorage.setItem("base_url", normalized_base_url);
       localStorage.setItem("home_server_url", json.home_server);

--- a/src/synapse/authProvider.js
+++ b/src/synapse/authProvider.js
@@ -21,7 +21,7 @@ const getBaseUrl = (login_base_url, json_base_url, force_server) => {
   } else {
     return json_base_url;
   }
-}
+};
 
 const authProvider = {
   // called when the user attempts to log in


### PR DESCRIPTION
Related to #16 
Fixes: #16 and probably #29 
Add a switch to login form. The switch decide which server address is used for `base_url`. Either given address from login form (forced) or `m.homeserver` from well-known entry of login response.