### PR TITLE
Allow port in homeserver URL

### DIFF
--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -103,7 +103,9 @@ const LoginPage = ({ theme }) => {
     } else {
       if (!values.base_url.match(/^(http|https):\/\//)) {
         errors.base_url = translate("synapseadmin.auth.protocol_error");
-      } else if (!values.base_url.match(/^(http|https):\/\/[a-zA-Z0-9\-.]+$/)) {
+      } else if (
+        !values.base_url.match(/^(http|https):\/\/[a-zA-Z0-9\-.]+(:\d{1,5})?$/)
+      ) {
         errors.base_url = translate("synapseadmin.auth.url_error");
       }
     }


### PR DESCRIPTION
Allow to use homeserver URL with port (e.g. ':443').