### PR TITLE
Bugfix sort users by `user_id`

### DIFF
--- a/src/components/users.js
+++ b/src/components/users.js
@@ -78,7 +78,7 @@ export const UserList = props => (
       >
         <ImageField source="avatar_url" title="displayname" />
       </ReferenceField>
-      <TextField source="id" />
+      <TextField source="id" sortable={false} />
       {/* Hack since the users endpoint does not give displaynames in the list*/}
       <ReferenceField
         source="name"


### PR DESCRIPTION
Users are not sortable by `user_id`.
Set `sortable={false}`.