### PR TITLE
Bugfix removes the ability to click on individual connections.

### DIFF
--- a/src/components/users.js
+++ b/src/components/users.js
@@ -176,7 +176,12 @@ export const UserEdit = props => (
         label="resources.connections.name"
         icon={<SettingsInputComponentIcon />}
       >
-        <ReferenceField reference="connections" source="id" addLabel={false}>
+        <ReferenceField
+          reference="connections"
+          source="id"
+          addLabel={false}
+          link={false}
+        >
           <ArrayField
             source="devices[].sessions[0].connections"
             label="resources.connections.name"


### PR DESCRIPTION
If you click on a connection in UserEdit, you will get an empty page.
This solves the problem.