### PR TITLE
Add new list with information about users' media

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,8 @@ import { RoomList, RoomShow } from "./components/rooms";
 import { ReportList, ReportShow } from "./components/EventReports";
 import LoginPage from "./components/LoginPage";
 import UserIcon from "@material-ui/icons/Group";
+import EqualizerIcon from "@material-ui/icons/Equalizer";
+import { UserMediaStatsList } from "./components/statistics";
 import RoomIcon from "@material-ui/icons/ViewList";
 import ReportIcon from "@material-ui/icons/Warning";
 import { ImportFeature } from "./components/ImportFeature";
@@ -43,6 +45,11 @@ const App = () => (
       icon={UserIcon}
     />
     <Resource name="rooms" list={RoomList} show={RoomShow} icon={RoomIcon} />
+    <Resource
+      name="user_media_statistics"
+      list={UserMediaStatsList}
+      icon={EqualizerIcon}
+    />
     <Resource
       name="reports"
       list={ReportList}

--- a/src/components/statistics.js
+++ b/src/components/statistics.js
@@ -1,0 +1,42 @@
+import React from "react";
+import {
+  Datagrid,
+  Filter,
+  List,
+  NumberField,
+  TextField,
+  SearchInput,
+  Pagination,
+} from "react-admin";
+
+const UserMediaStatsPagination = props => (
+  <Pagination {...props} rowsPerPageOptions={[10, 25, 50, 100, 500, 1000]} />
+);
+
+const UserMediaStatsFilter = props => (
+  <Filter {...props}>
+    <SearchInput source="search_term" alwaysOn />
+  </Filter>
+);
+
+export const UserMediaStatsList = props => {
+  return (
+    <List
+      {...props}
+      filters={<UserMediaStatsFilter />}
+      pagination={<UserMediaStatsPagination />}
+      sort={{ field: "media_length", order: "DESC" }}
+      bulkActionButtons={false}
+    >
+      <Datagrid rowClick={(id, basePath, record) => "/users/" + id + "/media"}>
+        <TextField source="user_id" label="resources.users.fields.id" />
+        <TextField
+          source="displayname"
+          label="resources.users.fields.displayname"
+        />
+        <NumberField source="media_count" />
+        <NumberField source="media_length" />
+      </Datagrid>
+    </List>
+  );
+};

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -239,6 +239,13 @@ export default {
           'Sendet eine Serverbenachrichtigung an die ausgewählten Nutzer. Hierfür muss das Feature "Server Notices" auf dem Server aktiviert sein.',
       },
     },
+    user_media_statistics: {
+      name: "Dateien je Benutzer",
+      fields: {
+        media_count: "Anzahl der Dateien",
+        media_length: "Größe der Dateien",
+      },
+    },
   },
   ra: {
     ...germanMessages.ra,

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -236,5 +236,12 @@ export default {
           'Sends a server notice to the selected users. The feature "Server Notices" has to be activated at the server.',
       },
     },
+    user_media_statistics: {
+      name: "Users' media",
+      fields: {
+        media_count: "Media count",
+        media_length: "Media length",
+      },
+    },
   },
 };

--- a/src/synapse/dataProvider.js
+++ b/src/synapse/dataProvider.js
@@ -127,6 +127,17 @@ const resourceMap = {
       method: "POST",
     }),
   },
+  user_media_statistics: {
+    path: "/_synapse/admin/v1/statistics/users/media",
+    map: usms => ({
+      ...usms,
+      id: usms.user_id,
+    }),
+    data: "users",
+    total: json => {
+      return json.total;
+    },
+  },
 };
 
 function filterNullValues(key, value) {


### PR DESCRIPTION
The api is new in Synapse 1.23.0.
The list is sortable and filterable.
It is a new list and not part of users' list because you have the chance to filter by date/time.
At the moment the date/time filter is missing in this PR. It needs a datetime picker with result in timestamp.
