### PR TITLE
Add `joined_local_devices` to rooms

### DIFF
--- a/src/components/rooms.js
+++ b/src/components/rooms.js
@@ -89,6 +89,7 @@ export const RoomShow = props => {
         >
           <TextField source="joined_members" />
           <TextField source="joined_local_members" />
+          <TextField source="joined_local_devices" />
           <TextField source="state_events" />
           <TextField source="version" />
           <TextField

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -141,6 +141,7 @@ export default {
         canonical_alias: "Alias",
         joined_members: "Mitglieder",
         joined_local_members: "Lokale Mitglieder",
+        joined_local_devices: "Lokale Endgeräte",
         state_events: "Ereignisse",
         version: "Version",
         is_encrypted: "Verschlüsselt",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -139,6 +139,7 @@ export default {
         canonical_alias: "Alias",
         joined_members: "Members",
         joined_local_members: "local members",
+        joined_local_devices: "local devices",
         state_events: "State events",
         version: "Version",
         is_encrypted: "Encrypted",


### PR DESCRIPTION
Add attribut of rooms `joined_local_devices` to detail view of rooms.
New in Synapse 1.25.0

Fixes #92 