### PR TITLE
Add github action that packages a release tarball

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,28 @@
+name: Create release tarball and attach to tag
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - run: yarn install
+      - run: yarn build
+      - run: |
+          version=`git describe --dirty --tags || echo unknown`
+          mkdir -p dist
+          cp -r build synapse-admin-$version
+          tar chvzf dist/synapse-admin-$version.tar.gz synapse-admin-$version
+      - uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf
+        with:
+          files: dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,12 +21,22 @@ See also [Synapse administration endpoints](https://matrix-org.github.io/synapse
 
 ## Step-By-Step install:
 
-You have two options:
+You have three options:
 
-1.  Download the source code from github and run using nodejs
-2.  Run the Docker container
+1.  Download the tarball and serve with any webserver
+2.  Download the source code from github and run using nodejs
+3.  Run the Docker container
 
 Steps for 1):
+
+- make sure you have a webserver installed that can serve static files (any webserver like nginx or apache will do)
+- configure a vhost for synapse admin on your webserver
+- download the .tar.gz from the latest release: https://github.com/Awesome-Technologies/synapse-admin/releases/latest
+- unpack the .tar.gz
+- move or symlink the `synapse-admin-x.x.x` into your vhosts root dir
+- open the url of the vhost in your browser
+
+Steps for 2):
 
 - make sure you have installed the following: git, yarn, nodejs
 - download the source code: `git clone https://github.com/Awesome-Technologies/synapse-admin.git`
@@ -39,7 +49,7 @@ Either you define it at startup (e.g. `REACT_APP_SERVER=https://yourmatrixserver
 or by editing it in the [.env](.env) file. See also the
 [documentation](https://create-react-app.dev/docs/adding-custom-environment-variables/).
 
-Steps for 2):
+Steps for 3):
 
 - run the Docker container from the public docker registry: `docker run -p 8080:80 awesometechnologies/synapse-admin` or use the [docker-compose.yml](docker-compose.yml): `docker-compose up -d`
 


### PR DESCRIPTION
This action builds and packages everything into a static site that
can be deployed on any webserver at runtime.

It automatically runs on every pushed tag, ie every release