### PR TITLE
Change delete room API to `DELETE`

### DIFF
--- a/src/synapse/dataProvider.js
+++ b/src/synapse/dataProvider.js
@@ -67,9 +67,8 @@ const resourceMap = {
       return json.total_rooms;
     },
     delete: params => ({
-      endpoint: `/_synapse/admin/v1/rooms/${params.id}/delete`,
+      endpoint: `/_synapse/admin/v1/rooms/${params.id}`,
       body: { block: false },
-      method: "POST",
     }),
   },
   reports: {


### PR DESCRIPTION
Fixes: #149 
The old API is deprecated in Synapse 1.34.0 (2021-05-17).