### PR TITLE
Room Erase title and content not localized

### DIFF
--- a/src/components/rooms.js
+++ b/src/components/rooms.js
@@ -111,8 +111,8 @@ const RoomShowActions = ({ basePath, data, resource }) => {
         record={data}
         resource={resource}
         mutationMode="pessimistic"
-        confirmTitle="resources.rooms.action.erase.title"
-        confirmContent="resources.rooms.action.erase.content"
+        confirmTitle="resources.rooms.erase.title"
+        confirmContent="resources.rooms.erase.content"
       />
     </TopToolbar>
   );
@@ -313,8 +313,8 @@ const RoomBulkActionButtons = props => (
     <RoomDirectoryBulkDeleteButton {...props} />
     <BulkDeleteButton
       {...props}
-      confirmTitle="resources.rooms.action.erase.title"
-      confirmContent="resources.rooms.action.erase.content"
+      confirmTitle="resources.rooms.erase.title"
+      confirmContent="resources.rooms.erase.content"
       undoable={false}
     />
   </Fragment>


### PR DESCRIPTION
In the i18n the correct localization is resources.rooms.erase, however the app attempts to localize resources.rooms.action.erase