### PR TITLE
replace `undoable` prop with `mutationMode` prop

### DIFF
--- a/src/components/RoomDirectory.js
+++ b/src/components/RoomDirectory.js
@@ -59,7 +59,7 @@ export const RoomDirectoryBulkDeleteButton = props => (
   <BulkDeleteButton
     {...props}
     label="resources.room_directory.action.erase"
-    undoable={false}
+    mutationMode="pessimistic"
     confirmTitle="resources.room_directory.action.title"
     confirmContent="resources.room_directory.action.content"
     resource="room_directory"

--- a/src/components/rooms.js
+++ b/src/components/rooms.js
@@ -315,7 +315,7 @@ const RoomBulkActionButtons = props => (
       {...props}
       confirmTitle="resources.rooms.action.erase.title"
       confirmContent="resources.rooms.action.erase.content"
-      undoable={false}
+      mutationMode="pessimistic"
     />
   </Fragment>
 );

--- a/src/components/users.js
+++ b/src/components/users.js
@@ -142,7 +142,7 @@ const UserBulkActionButtons = props => (
       {...props}
       label="resources.users.action.erase"
       confirmTitle="resources.users.helper.erase"
-      undoable={false}
+      mutationMode="pessimistic"
     />
   </Fragment>
 );


### PR DESCRIPTION
This will be removed in version 4 of react admin.

Upgrade notes:
https://github.com/marmelab/react-admin/blob/next/UPGRADE.md#removed-the-undoable-prop-in-favor-of-mutationmode

Docs:
https://marmelab.com/react-admin/CreateEdit.html#mutationmode