### PR TITLE
Switch Dockerfile to use current LTS version of Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM node:current as builder
+FROM node:lts as builder
 
 WORKDIR /src
 


### PR DESCRIPTION
Node 17 current fails due to https://github.com/webpack/webpack/issues/14532. It probably makes sense to use the current LTS version of Node instead of the absolute latest version of Node so these kinds of bleeding edge issues are less likely to happen.