### PR TITLE
Add edit `user_type` to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This project is built using [react-admin](https://marmelab.com/react-admin/).
 
-It needs at least Synapse v1.41.0 for all functions to work as expected!
+It needs at least Synapse v1.46.0 for all functions to work as expected!
 
 You get your server version with the request `/_synapse/admin/v1/server_version`.
 See also [Synapse version API](https://matrix-org.github.io/synapse/develop/admin_api/version_api.html).

--- a/src/components/users.js
+++ b/src/components/users.js
@@ -71,6 +71,16 @@ const useStyles = makeStyles({
   },
 });
 
+const choices_medium = [
+  { id: "email", name: "resources.users.email" },
+  { id: "msisdn", name: "resources.users.msisdn" },
+];
+
+const choices_type = [
+  { id: "bot", name: "bot" },
+  { id: "support", name: "support" },
+];
+
 const UserListActions = ({
   currentSort,
   className,
@@ -261,15 +271,19 @@ export const UserCreate = props => (
         autoComplete="new-password"
         validate={maxLength(512)}
       />
+      <SelectInput
+        source="user_type"
+        choices={choices_type}
+        translateChoice={false}
+        allowEmpty={true}
+        resettable
+      />
       <BooleanInput source="admin" />
       <ArrayInput source="threepids">
         <SimpleFormIterator>
           <SelectInput
             source="medium"
-            choices={[
-              { id: "email", name: "resources.users.email" },
-              { id: "msisdn", name: "resources.users.msisdn" },
-            ]}
+            choices={choices_medium}
             validate={required()}
           />
           <TextInput source="address" validate={validateAddress} />
@@ -300,6 +314,7 @@ const UserTitle = ({ record }) => {
     </span>
   );
 };
+
 export const UserEdit = props => {
   const classes = useStyles();
   const translate = useTranslate();
@@ -318,6 +333,13 @@ export const UserEdit = props => {
           <TextInput source="id" disabled />
           <TextInput source="displayname" />
           <PasswordInput source="password" autoComplete="new-password" />
+          <SelectInput
+            source="user_type"
+            choices={choices_type}
+            translateChoice={false}
+            allowEmpty={true}
+            resettable
+          />
           <BooleanInput source="admin" />
           <BooleanInput
             source="deactivated"
@@ -345,13 +367,7 @@ export const UserEdit = props => {
         >
           <ArrayInput source="threepids">
             <SimpleFormIterator>
-              <SelectInput
-                source="medium"
-                choices={[
-                  { id: "email", name: "resources.users.email" },
-                  { id: "msisdn", name: "resources.users.msisdn" },
-                ]}
-              />
+              <SelectInput source="medium" choices={choices_medium} />
               <TextInput source="address" />
             </SimpleFormIterator>
           </ArrayInput>

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -121,6 +121,7 @@ const de = {
         creation_ts_ms: "Zeitpunkt der Erstellung",
         consent_version: "Zugestimmte Geschäftsbedingungen",
         auth_provider: "Provider",
+        user_type: "Benutzertyp",
       },
       helper: {
         deactivate:

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -120,6 +120,7 @@ const en = {
         creation_ts_ms: "Creation timestamp",
         consent_version: "Consent version",
         auth_provider: "Provider",
+        user_type: "User type",
       },
       helper: {
         deactivate: "You must provide a password to re-activate an account.",

--- a/src/synapse/dataProvider.js
+++ b/src/synapse/dataProvider.js
@@ -279,7 +279,8 @@ const resourceMap = {
 
 function filterNullValues(key, value) {
   // Filtering out null properties
-  if (value === null) {
+  // to reset user_type from user, it must be null
+  if (value === null && key !== "user_type") {
     return undefined;
   }
   return value;


### PR DESCRIPTION
new in Synapse v1.46.0
To reset a user to a "normal" user `user_type` must be `null`.
https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#create-or-modify-account