### PR TITLE
Add session logout warning below password input

### DIFF
--- a/src/components/users.js
+++ b/src/components/users.js
@@ -317,7 +317,11 @@ export const UserEdit = props => {
           />
           <TextInput source="id" disabled />
           <TextInput source="displayname" />
-          <PasswordInput source="password" autoComplete="new-password" />
+          <PasswordInput
+            source="password"
+            autoComplete="new-password"
+            helperText="resources.users.helper.password"
+          />
           <BooleanInput source="admin" />
           <BooleanInput
             source="deactivated"

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -123,6 +123,7 @@ const de = {
         auth_provider: "Provider",
       },
       helper: {
+        password: "Durch die Änderung des Passworts wird der Benutzer von allen Sitzungen abgemeldet.",
         deactivate:
           "Sie müssen ein Passwort angeben, um ein Konto wieder zu aktivieren.",
         erase: "DSGVO konformes Löschen der Benutzerdaten",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -122,6 +122,7 @@ const en = {
         auth_provider: "Provider",
       },
       helper: {
+        password: "Changing password will log user out of all sessions.",
         deactivate: "You must provide a password to re-activate an account.",
         erase: "Mark the user as GDPR-erased",
       },


### PR DESCRIPTION
![obraz](https://user-images.githubusercontent.com/46846000/143662272-6342a712-ba21-4b02-bce0-d5330da76d49.png)

One of my users forgot their password and asked me to change it, which resulted in me unknowingly wiping all of their sessions as a result (due to lack of backup the E2EE keys were also lost). Had I been warned about it before I would've seeked another solution, hence I'm proposing this PR.

Reference: https://matrix-org.github.io/synapse/develop/admin_api/user_admin_api.html#create-or-modify-account
> `password` - string, optional. If provided, the user's password is updated and all devices are logged out.

I'm not sure how translations should be handled - I'm not fluent in the other two languages and didn't want to add a machine generated translation.