### PR TITLE
`disableReordering` in users' `SimpleFormIterator`

### DIFF
--- a/src/components/users.js
+++ b/src/components/users.js
@@ -276,7 +276,7 @@ export const UserCreate = props => (
       />
       <BooleanInput source="admin" />
       <ArrayInput source="threepids">
-        <SimpleFormIterator>
+        <SimpleFormIterator disableReordering>
           <SelectInput
             source="medium"
             choices={[
@@ -289,7 +289,7 @@ export const UserCreate = props => (
         </SimpleFormIterator>
       </ArrayInput>
       <ArrayInput source="external_ids" label="synapseadmin.users.tabs.sso">
-        <SimpleFormIterator>
+        <SimpleFormIterator disableReordering>
           <TextInput source="auth_provider" validate={required()} />
           <TextInput
             source="external_id"
@@ -357,7 +357,7 @@ export const UserEdit = props => {
           path="threepid"
         >
           <ArrayInput source="threepids">
-            <SimpleFormIterator>
+            <SimpleFormIterator disableReordering>
               <SelectInput
                 source="medium"
                 choices={[
@@ -376,7 +376,7 @@ export const UserEdit = props => {
           path="sso"
         >
           <ArrayInput source="external_ids" label={false}>
-            <SimpleFormIterator>
+            <SimpleFormIterator disableReordering>
               <TextInput source="auth_provider" validate={required()} />
               <TextInput
                 source="external_id"


### PR DESCRIPTION
Disable not needed ordering in SimpleFormIterator

New feature in [react-admin 3.18.0](https://github.com/marmelab/react-admin/releases/tag/v3.18.0)
> `<SimpleFormIterator>`: Add support for reordering items

PR: https://github.com/marmelab/react-admin/pull/6433

![125472471-a706dc74-5022-43ff-9c54-c05b652f272c 1](https://user-images.githubusercontent.com/5740567/147886948-3ec2860b-d830-4608-b47a-ce543dbdc322.gif)
