### PR TITLE
Replace deprecated `fade` in `devices.js`

### DIFF
--- a/src/components/devices.js
+++ b/src/components/devices.js
@@ -8,7 +8,7 @@ import {
 } from "react-admin";
 import ActionDelete from "@material-ui/icons/Delete";
 import { makeStyles } from "@material-ui/core/styles";
-import { fade } from "@material-ui/core/styles/colorManipulator";
+import { alpha } from "@material-ui/core/styles/colorManipulator";
 import classnames from "classnames";
 
 const useStyles = makeStyles(
@@ -16,7 +16,7 @@ const useStyles = makeStyles(
     deleteButton: {
       color: theme.palette.error.main,
       "&:hover": {
-        backgroundColor: fade(theme.palette.error.main, 0.12),
+        backgroundColor: alpha(theme.palette.error.main, 0.12),
         // Reset on mouse devices
         "@media (hover: none)": {
           backgroundColor: "transparent",


### PR DESCRIPTION
```
Material-UI: The `fade` color utility was renamed to `alpha` to better describe its functionality.
You should use `import { alpha } from '@material-ui/core/styles'`
```

For example: https://github.com/marmelab/react-admin/blob/5650aa677e8ccf256822a5bbe76c2a26ad74cd31/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx#L22-L36

Doc: https://mui.com/guides/migration-v4/#styles