### PR TITLE
Create `UserEditActions` on user page

### DIFF
--- a/src/components/users.js
+++ b/src/components/users.js
@@ -247,20 +247,26 @@ export function generateRandomUser() {
   };
 }
 
-const UserEditToolbar = props => {
+const UserEditToolbar = props => (
+  <Toolbar {...props}>
+    <SaveButton submitOnEnter={true} disabled={props.pristine} />
+  </Toolbar>
+);
+
+const UserEditActions = ({ data }) => {
   const translate = useTranslate();
   return (
-    <Toolbar {...props}>
-      <SaveButton submitOnEnter={true} disabled={props.pristine} />
+    <TopToolbar>
+      {!data.deactivated && <ServerNoticeButton record={data} />}
       <DeleteButton
+        record={data}
         label="resources.users.action.erase"
         confirmTitle={translate("resources.users.helper.erase", {
           smart_count: 1,
         })}
         mutationMode="pessimistic"
       />
-      <ServerNoticeButton />
-    </Toolbar>
+    </TopToolbar>
   );
 };
 
@@ -313,11 +319,12 @@ const UserTitle = ({ record }) => {
     </span>
   );
 };
+
 export const UserEdit = props => {
   const classes = useStyles();
   const translate = useTranslate();
   return (
-    <Edit {...props} title={<UserTitle />}>
+    <Edit {...props} title={<UserTitle />} actions={<UserEditActions />}>
       <TabbedForm toolbar={<UserEditToolbar />}>
         <FormTab
           label={translate("resources.users.name", { smart_count: 1 })}

--- a/src/components/users.js
+++ b/src/components/users.js
@@ -255,9 +255,14 @@ const UserEditToolbar = props => (
 
 const UserEditActions = ({ data }) => {
   const translate = useTranslate();
+  var userStatus = "";
+  if (data) {
+    userStatus = data.deactivated;
+  }
+
   return (
     <TopToolbar>
-      {!data.deactivated && <ServerNoticeButton record={data} />}
+      {!userStatus && <ServerNoticeButton record={data} />}
       <DeleteButton
         record={data}
         label="resources.users.action.erase"


### PR DESCRIPTION
- Move actions for users to the top.
- Show send notice button only if user is activated.

![image](https://user-images.githubusercontent.com/5740567/148381735-b93840e0-12c1-479f-9fdc-839c70bc98c6.png)

The idea:
- The same design as for the rooms. For the rooms, the actions are also at the top.
- Separate "normale" edit / save button for user from general actions
- Space for further actions, eg.
  - [Quarantining all media of a user](https://matrix-org.github.io/synapse/latest/admin_api/media_admin_api.html#quarantining-all-media-of-a-user)
  - [Delete media uploaded by a user](https://matrix-org.github.io/synapse/latest/admin_api/media_admin_api.html#delete-media-uploaded-by-a-user)