### PR TITLE
Fix typo in `.prettierrc`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,5 @@
   "trailingComma": "es5",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "arrowParens": "avoid",
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
Introduced in https://github.com/Awesome-Technologies/synapse-admin/commit/2240559f74e18d0c0f9fe0d3df399569e2e22136#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2