### PR TITLE
Migrate `useMutation` to `useDelete` in `devices.js`

### DIFF
--- a/src/components/devices.js
+++ b/src/components/devices.js
@@ -1,11 +1,5 @@
 import React, { Fragment, useState } from "react";
-import {
-  Button,
-  useMutation,
-  useNotify,
-  Confirm,
-  useRefresh,
-} from "react-admin";
+import { Button, useDelete, useNotify, Confirm, useRefresh } from "react-admin";
 import ActionDelete from "@material-ui/icons/Delete";
 import { makeStyles } from "@material-ui/core/styles";
 import { fade } from "@material-ui/core/styles/colorManipulator";
@@ -34,7 +28,7 @@ export const DeviceRemoveButton = props => {
   const refresh = useRefresh();
   const notify = useNotify();
 
-  const [removeDevice, { loading }] = useMutation();
+  const [removeDevice, { isLoading }] = useDelete("devices");
 
   if (!record) return null;
 
@@ -43,21 +37,15 @@ export const DeviceRemoveButton = props => {
 
   const handleConfirm = () => {
     removeDevice(
-      {
-        type: "delete",
-        resource: "devices",
-        payload: {
-          id: record.id,
-          user_id: record.user_id,
-        },
-      },
+      { payload: { id: record.id, user_id: record.user_id } },
       {
         onSuccess: () => {
           notify("resources.devices.action.erase.success");
           refresh();
         },
-        onFailure: () =>
-          notify("resources.devices.action.erase.failure", "error"),
+        onFailure: () => {
+          notify("resources.devices.action.erase.failure", "error");
+        },
       }
     );
     setOpen(false);
@@ -74,7 +62,7 @@ export const DeviceRemoveButton = props => {
       </Button>
       <Confirm
         isOpen={open}
-        loading={loading}
+        loading={isLoading}
         onConfirm={handleConfirm}
         onClose={handleDialogClose}
         title="resources.devices.action.erase.title"

--- a/src/components/devices.js
+++ b/src/components/devices.js
@@ -44,7 +44,7 @@ export const DeviceRemoveButton = props => {
           refresh();
         },
         onFailure: () => {
-          notify("resources.devices.action.erase.failure", "error");
+          notify("resources.devices.action.erase.failure", { type: "error" });
         },
       }
     );


### PR DESCRIPTION
`useMutation` have been removed in React Admin v4.
`useDelete` is also valid in React Admin 3.

https://github.com/marmelab/react-admin/blob/next/UPGRADE.md#usequery-usemutation-and-usequerywithstore-have-been-removed