### PR TITLE
Add `path` to "members" tab in `ShowRooms`

### DIFF
--- a/src/components/rooms.js
+++ b/src/components/rooms.js
@@ -149,7 +149,11 @@ export const RoomShow = props => {
           />
         </Tab>
 
-        <Tab label="synapseadmin.rooms.tabs.members" icon={<UserIcon />}>
+        <Tab
+          label="synapseadmin.rooms.tabs.members"
+          icon={<UserIcon />}
+          path="members"
+        >
           <ReferenceManyField
             reference="room_members"
             target="room_id"


### PR DESCRIPTION
The `path` is missing at the moment.