### PR TITLE
Adjusted Dockerfile to include args in build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Builder
 FROM node:lts as builder
 
+ARG PUBLIC_URL=/
+ARG REACT_APP_SERVER
+
 WORKDIR /src
 
 COPY . /src
 RUN yarn --network-timeout=100000 install
-RUN yarn build
+RUN PUBLIC_URL=$PUBLIC_URL REACT_APP_SERVER=$REACT_APP_SERVER yarn build
 
 
 # App

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ or by editing it in the [.env](.env) file. See also the
         context: https://github.com/Awesome-Technologies/synapse-admin.git
         # args:
         #   - NODE_OPTIONS="--max_old_space_size=1024"
+        #   # see #266
+        #   - PUBLIC_URL="/synapse-admin"
+        #   - REACT_APP_SERVER="https://matrix.example.com"
       ports:
         - "8080:80"
       restart: unless-stopped


### PR DESCRIPTION
Closes #265 (see for more details and use-case)

This PR adds the two build variables `PUBLIC_URL` and `REACT_APP_SERVER` as argument to the docker build process.

While `PUBLIC_URL` has the default value of `/` if not set, `REACT_APP_SERVER` won't be used at all if not set.