### PR TITLE
Bump GHA to NodeJS v16

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Run tests

--- a/.github/workflows/edge_ghpage.yml
+++ b/.github/workflows/edge_ghpage.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2.3.1
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
       - name: Install and Build 🔧
         run: |
           yarn install

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "16"
       - run: yarn install
       - run: yarn build
       - run: |


### PR DESCRIPTION
Life cycle / eol of NodeJS: https://endoflife.date/nodejs