### PR TITLE
Delete Room API v2

### DIFF
--- a/src/synapse/dataProvider.js
+++ b/src/synapse/dataProvider.js
@@ -69,8 +69,8 @@ const resourceMap = {
       return json.total_rooms;
     },
     delete: params => ({
-      endpoint: `/_synapse/admin/v1/rooms/${params.id}`,
-      body: { block: false },
+      endpoint: `/_synapse/admin/v2/rooms/${params.id}`,
+      body: { purge: true },
     }),
   },
   reports: {


### PR DESCRIPTION
Ref: https://matrix-org.github.io/synapse/latest/admin_api/rooms.html#version-2-new-version
Empty body returns `400 Bad Request`, so the default `purge: true` is sent