### PR TITLE
docker-compose.yml: fix indentation, add args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,20 @@ services:
     hostname: synapse-admin
     image: awesometechnologies/synapse-admin:latest
     # build:
-    # context: .
+      # context: .
 
-    # to use the docker-compose as standalone without a local repo clone,
-    # replace the context definition with this:
-    # context: https://github.com/Awesome-Technologies/synapse-admin.git
+      # to use the docker-compose as standalone without a local repo clone,
+      # replace the context definition with this:
+      # context: https://github.com/Awesome-Technologies/synapse-admin.git
 
-    # if you're building on an architecture other than amd64, make sure
-    # to define a maximum ram for node. otherwise the build will fail.
-    # args:
-    #   - NODE_OPTIONS="--max_old_space_size=1024"
+      # args:
+        # if you're building on an architecture other than amd64, make sure
+        # to define a maximum ram for node. otherwise the build will fail.
+        # - NODE_OPTIONS="--max_old_space_size=1024"
+        # default is /
+        # - PUBLIC_URL="/synapse-admin"
+        # You can fix the homeserver, so that the user can no longer define it himself
+        # - REACT_APP_SERVER="https://matrix.example.com"
     ports:
       - "8080:80"
     restart: unless-stopped


### PR DESCRIPTION
fix the indentation
add the args as example, as described in the README