### PR TITLE
Set `dist` for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: node_js
 node_js:
   - lts/*


### PR DESCRIPTION
Try to fix failure in #297 and #299

Default seems to be `"dist": "xenial"`, https://app.travis-ci.com/github/Awesome-Technologies/synapse-admin/jobs/590193485/config and https://docs.travis-ci.com/user/reference/linux/#overview

See discussion: https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/