### PR TITLE
Fixed language displayed in login page

### DIFF
--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -332,6 +332,7 @@ const LoginPage = ({ theme }) => {
                     <MenuItem value="de">Deutsch</MenuItem>
                     <MenuItem value="en">English</MenuItem>
                     <MenuItem value="fr">Français</MenuItem>
+                    <MenuItem value="it">Italiano</MenuItem>
                     <MenuItem value="zh">简体中文</MenuItem>
                   </Select>
                 </div>


### PR DESCRIPTION
In the PR merged today (#374) I forgot to insert the entry for the Italian language in the login page so that it was visible for the selection.
This mainly because the page on startup takes the local of the machine and during the tests I found it already in Italian.
My bad.