### PR TITLE
Add locked users filter and lock option

### DIFF
--- a/public/data/example.csv
+++ b/public/data/example.csv
@@ -1,3 +1,3 @@
-id,displayname,password,is_guest,admin,deactivated
+id,displayname,password,is_guest,admin,deactivated,locked
 @testuser22:example.org,Jane Doe,secretpassword,false,true,false
-,John Doe,,false,false,false
+,John Doe,,false,false,false,false

--- a/src/components/ImportFeature.js
+++ b/src/components/ImportFeature.js
@@ -42,6 +42,7 @@ const optionalFields = [
   "guest",
   "admin",
   "deactivated",
+  "locked",
   "avatar_url",
   "password",
 ].sort();
@@ -143,6 +144,7 @@ const FilePicker = props => {
       is_guest: 0,
       admin: 0,
       deactivated: 0,
+      locked: 0,
       password: 0,
       avatar_url: 0,
       id: 0,
@@ -171,7 +173,7 @@ const FilePicker = props => {
         delete line.is_admin;
       }
 
-      ["is_guest", "admin", "deactivated"].forEach(f => {
+      ["is_guest", "admin", "deactivated", "locked"].forEach(f => {
         if (line[f] === "true") {
           stats[f]++;
           line[f] = true; // we need true booleans instead of strings

--- a/src/components/users.js
+++ b/src/components/users.js
@@ -154,6 +154,11 @@ const UserFilter = props => (
       source="deactivated"
       alwaysOn
     />
+    <BooleanInput
+      label="resources.users.fields.show_locked"
+      source="locked"
+      alwaysOn
+    />
   </Filter>
 );
 
@@ -179,7 +184,7 @@ export const UserList = props => {
     <List
       {...props}
       filters={<UserFilter />}
-      filterDefaultValues={{ guests: true, deactivated: false }}
+      filterDefaultValues={{ guests: true, deactivated: false, locked: false }}
       sort={{ field: "name", order: "ASC" }}
       actions={<UserListActions maxResults={10000} />}
       bulkActionButtons={<UserBulkActionButtons />}
@@ -196,6 +201,7 @@ export const UserList = props => {
         <BooleanField source="is_guest" />
         <BooleanField source="admin" />
         <BooleanField source="deactivated" />
+        <BooleanField source="locked" />
         <DateField
           source="creation_ts"
           label="resources.users.fields.creation_ts_ms"
@@ -218,6 +224,16 @@ const validateUser = [
 ];
 
 const validateAddress = [required(), maxLength(255)];
+
+const validateForm = values => {
+  const errors = {};
+
+  if (values.deactivated && values.locked) {
+    errors.locked = "resources.users.action.update.locked_and_deactivated";
+  }
+
+  return errors;
+};
 
 export function generateRandomUser() {
   const homeserver = localStorage.getItem("home_server");
@@ -348,7 +364,7 @@ export const UserEdit = props => {
   const translate = useTranslate();
   return (
     <Edit {...props} title={<UserTitle />} actions={<UserEditActions />}>
-      <TabbedForm toolbar={<UserEditToolbar />}>
+      <TabbedForm toolbar={<UserEditToolbar />} validate={validateForm}>
         <FormTab
           label={translate("resources.users.name", { smart_count: 1 })}
           icon={<PersonPinIcon />}
@@ -377,6 +393,7 @@ export const UserEdit = props => {
             source="deactivated"
             helperText="resources.users.helper.deactivate"
           />
+          <BooleanInput source="locked" />
           <DateField source="creation_ts_ms" showTime options={date_format} />
           <TextField source="consent_version" />
         </FormTab>

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -108,8 +108,10 @@ const de = {
         is_guest: "Gast",
         admin: "Server Administrator",
         deactivated: "Deaktiviert",
+        locked: "Gesperrt",
         guests: "Zeige Gäste",
         show_deactivated: "Zeige deaktivierte Benutzer",
+        show_locked: "Zeige gesperrte Benutzer",
         user_id: "Suche Benutzer",
         displayname: "Anzeigename",
         password: "Passwort",
@@ -132,6 +134,10 @@ const de = {
       },
       action: {
         erase: "Lösche Benutzerdaten",
+        update: {
+          locked_and_deactivated:
+            "Ein Benutzer kann nicht deaktiviert und gesperrt werden.",
+        },
       },
     },
     rooms: {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -107,8 +107,10 @@ const en = {
         is_guest: "Guest",
         admin: "Server Administrator",
         deactivated: "Deactivated",
+        locked: "locked",
         guests: "Show guests",
         show_deactivated: "Show deactivated users",
+        show_locked: "Show locked users",
         user_id: "Search user",
         displayname: "Displayname",
         password: "Password",
@@ -129,6 +131,9 @@ const en = {
       },
       action: {
         erase: "Erase user data",
+        update: {
+          locked_and_deactivated: "A user cannot be deactivated and locked.",
+        },
       },
     },
     rooms: {

--- a/src/synapse/dataProvider.js
+++ b/src/synapse/dataProvider.js
@@ -35,6 +35,7 @@ const resourceMap = {
       is_guest: !!u.is_guest,
       admin: !!u.admin,
       deactivated: !!u.deactivated,
+      locked: !!u.locked,
       // need timestamp in milliseconds
       creation_ts_ms: u.creation_ts * 1000,
     }),
@@ -355,6 +356,7 @@ const dataProvider = {
       name,
       guests,
       deactivated,
+      locked,
       search_term,
       destination,
       valid,
@@ -371,6 +373,7 @@ const dataProvider = {
       destination: destination,
       guests: guests,
       deactivated: deactivated,
+      locked: locked,
       valid: valid,
       order_by: field,
       dir: getSearchOrder(order),

--- a/src/synapse/dataProvider.test.js
+++ b/src/synapse/dataProvider.test.js
@@ -19,6 +19,7 @@ describe("dataProvider", () => {
             admin: 0,
             user_type: null,
             deactivated: 0,
+            locked: 0,
             displayname: "User One",
           },
           {
@@ -28,6 +29,7 @@ describe("dataProvider", () => {
             admin: 1,
             user_type: null,
             deactivated: 0,
+            locked: 0,
             displayname: "User Two",
           },
         ],
@@ -66,6 +68,7 @@ describe("dataProvider", () => {
         avatar_url: "mxc://localhost/user1",
         admin: false,
         deactivated: false,
+        locked: false,
       })
     );
 


### PR DESCRIPTION
Synapse v1.91.0 introduced the locked property for users. [MSC3939](https://github.com/matrix-org/matrix-spec-proposals/pull/3939)

In this PR:
- Add the locked filter option for the users list.
- Add the locked option to update for users with a form validation rule that a user cannot be locked and deactivated at the same time.