### PR TITLE
Bump NodeJS to v18

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: "18"
       - name: Install dependencies
         run: yarn --frozen-lockfile
       - name: Run tests

--- a/.github/workflows/edge_ghpage.yml
+++ b/.github/workflows/edge_ghpage.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Install and Build 🔧
         run: |
           yarn install

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
       - run: yarn install
       - run: yarn build
       - run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: focal
 language: node_js
 node_js:
-  - 17
+  - 18
 
 cache: yarn


### PR DESCRIPTION
Life cycle / eol of NodeJS v16 (11 Sep 2023): https://endoflife.date/nodejs