### PR TITLE
disallow crawling in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: *

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow: /


### PR DESCRIPTION
For an admin GUI it makes no sense to invite crawlers.

It has no additional functional value.