### PR TITLE
Allow deletion of event reports

### DIFF
--- a/src/components/EventReports.jsx
+++ b/src/components/EventReports.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Datagrid,
   DateField,
+  DeleteButton,
   List,
   NumberField,
   Pagination,
@@ -10,6 +11,8 @@ import {
   Tab,
   TabbedShowLayout,
   TextField,
+  TopToolbar,
+  useRecordContext,
   useTranslate,
 } from "react-admin";
 import PageviewIcon from "@mui/icons-material/Pageview";
@@ -32,7 +35,7 @@ const ReportPagination = () => (
 export const ReportShow = props => {
   const translate = useTranslate();
   return (
-    <Show {...props}>
+    <Show {...props} actions={<ReportShowActions />}>
       <TabbedShowLayout>
         <Tab
           label={translate("synapseadmin.reports.tabs.basic", {
@@ -96,6 +99,21 @@ export const ReportShow = props => {
         </Tab>
       </TabbedShowLayout>
     </Show>
+  );
+};
+
+const ReportShowActions = () => {
+  const record = useRecordContext();
+
+  return (
+    <TopToolbar>
+      <DeleteButton
+        record={record}
+        mutationMode="pessimistic"
+        confirmTitle="resources.reports.action.erase.title"
+        confirmContent="resources.reports.action.erase.content"
+      />
+    </TopToolbar>
   );
 };
 

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -188,7 +188,7 @@ const de = {
       },
     },
     reports: {
-      name: "Ereignisbericht |||| Ereignisberichte",
+      name: "Gemeldetes Ereignis |||| Gemeldete Ereignisse",
       fields: {
         id: "ID",
         received_ts: "Meldezeit",

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -210,6 +210,13 @@ const de = {
           },
         },
       },
+      action: {
+        erase: {
+          title: "Gemeldetes Event löschen",
+          content:
+            "Sind Sie sicher dass Sie das gemeldete Event löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+        },
+      },
     },
     connections: {
       name: "Verbindungen",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -207,6 +207,13 @@ const en = {
           },
         },
       },
+      action: {
+        erase: {
+          title: "Delete reported event",
+          content:
+            "Are you sure you want to delete the reported event? This cannot be undone.",
+        },
+      },
     },
     connections: {
       name: "Connections",


### PR DESCRIPTION
This pull request adds an action to delete event reports. (API: https://matrix-org.github.io/synapse/develop/admin_api/event_reports.html#delete-a-specific-event-report)

It also changes the german translation of the tab name, to something that I think is more fitting. (Can be removed if wished.)

Closes #444 

Note about translations: Since I added a new action, I also had to add some new keys. I only speak English and German, so I wasn't able to translate it to the other languages. I don't know if I have to add these keys anyway to the other languages, and if yes, what I should insert there instead.