### PR TITLE
Disable bulkActionButtons for not needed room and user tabs

### DIFF
--- a/src/components/rooms.jsx
+++ b/src/components/rooms.jsx
@@ -134,6 +134,7 @@ export const RoomShow = props => {
             <Datagrid
               style={{ width: "100%" }}
               rowClick={(id, resource, record) => "/users/" + id}
+              bulkActionButtons={false}
             >
               <TextField
                 source="id"
@@ -218,7 +219,7 @@ export const RoomShow = props => {
             target="room_id"
             addLabel={false}
           >
-            <Datagrid style={{ width: "100%" }}>
+            <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
               <TextField source="type" sortable={false} />
               <DateField
                 source="origin_server_ts"
@@ -256,7 +257,7 @@ export const RoomShow = props => {
             target="room_id"
             addLabel={false}
           >
-            <Datagrid style={{ width: "100%" }}>
+            <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
               <TextField source="id" sortable={false} />
               <DateField
                 source="received_ts"

--- a/src/components/users.jsx
+++ b/src/components/users.jsx
@@ -417,7 +417,7 @@ export const UserEdit = props => {
               source="devices[].sessions[0].connections"
               label="resources.connections.name"
             >
-              <Datagrid style={{ width: "100%" }}>
+              <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
                 <TextField source="ip" sortable={false} />
                 <DateField
                   source="last_seen"
@@ -480,6 +480,7 @@ export const UserEdit = props => {
             <Datagrid
               style={{ width: "100%" }}
               rowClick={(id, resource, record) => "/rooms/" + id + "/show"}
+              bulkActionButtons={false}
             >
               <TextField
                 source="id"
@@ -509,7 +510,7 @@ export const UserEdit = props => {
             target="user_id"
             addLabel={false}
           >
-            <Datagrid style={{ width: "100%" }}>
+            <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
               <TextField source="kind" sortable={false} />
               <TextField source="app_display_name" sortable={false} />
               <TextField source="app_id" sortable={false} />


### PR DESCRIPTION
Disable `bulkActionButtons` for objects where no action is defined or or the meaning is misleading.

For example, in the room list of users. Deleting does not kick the user from the room, but deletes the entire room.

affected:
- user
  - connections / sessions (no action implemented)
  - joined_rooms (misleading)
  - pushers (no action implemented)
- rooms
  - members (misleading)
  - forward_extremities (no action implemented)