### PR TITLE
Update RegistrationTokens.jsx: Fix resource name

### DIFF
--- a/src/components/RegistrationTokens.jsx
+++ b/src/components/RegistrationTokens.jsx
@@ -132,7 +132,7 @@ export const RegistrationTokenEdit = props => (
 );
 
 const resource = {
-  name: "users",
+  name: "registration_tokens",
   icon: RegistrationTokenIcon,
   list: RegistrationTokenList,
   edit: RegistrationTokenEdit,


### PR DESCRIPTION
Previously:
![image](https://github.com/dklimpel/synapse-admin/assets/199050/431a602e-af11-4726-8a7c-a9b5f55d8753)
Now:
![image](https://github.com/dklimpel/synapse-admin/assets/199050/7db820f5-989d-43f4-ad36-0b4dff7eb5ed)


fixes #468