### PR TITLE
Added identifier field to login request

### DIFF
--- a/src/synapse/authProvider.js
+++ b/src/synapse/authProvider.js
@@ -21,6 +21,10 @@ const authProvider = {
                 token: loginToken,
               }
             : {
+                identifier: {
+                  type: "m.id.user",
+                  user: username,
+                },
                 type: "m.login.password",
                 user: username,
                 password: password,


### PR DESCRIPTION
I am using a microservice for my server deployment that handles `/login` requests, which uses the `identifier` field of the login request instead of using the deprecated `user` field (https://spec.matrix.org/v1.9/client-server-api/#post_matrixclientv3login). I added the `identifier` field to the login request for better compatibility.

I kept the deprecated `user` field in the request, but I can remove it if desired as well.
