### PR TITLE
Add identifier when login with password

### DIFF
--- a/src/synapse/authProvider.js
+++ b/src/synapse/authProvider.js
@@ -24,6 +24,10 @@ const authProvider = {
                 type: "m.login.password",
                 user: username,
                 password: password,
+                identifier: {
+                  type: "m.id.user",
+                  user: username,
+                },
               }
         )
       ),


### PR DESCRIPTION
Since Matrix spec v1, the username when login with password should be sent in the `identifier` field, as explained here: https://spec.matrix.org/v1.1/client-server-api/#matrix-user-id

A full example of a password based login payload can be found here: https://spec.matrix.org/v1.1/client-server-api/#password-based