### PR TITLE
Add source urls to docker so tools can find sourcecode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Builder
 FROM node:lts as builder
-
+LABEL org.opencontainers.image.url=https://github.com/Awesome-Technologies/synapse-admin org.opencontainers.image.source=https://github.com/Awesome-Technologies/synapse-admin
 ARG REACT_APP_SERVER
 
 WORKDIR /src


### PR DESCRIPTION
For tools like renovate or dependabot, they like to put changelog notes in PRs updating deps. Having the labels allows the tools to link it back to sourcecode and share commits/release notes

If you want, I can update your github actions to use docker/metadata-action like i did for https://github.com/plankanban/planka/pull/680/files