### PR TITLE
use relative paths for assets to run not in docroot

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  base: "./",
   plugins: [
     react(),
     vitePluginVersionMark({


### PR DESCRIPTION
Bring back, that the index.html load asstes with relative paths that using in root path ist not required.

`src=/assets/` -> `src=./assets/`

Fixes:
- #517
- #519

Related to:
- #11 
- https://github.com/Awesome-Technologies/synapse-admin/commit/1002b6464a1093b000ebf1d3e9b26cb04526ff11