### PR TITLE
Add ability to toggle whether to show locked users

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -124,6 +124,7 @@ const en: SynapseTranslationMessages = {
         erased: "Erased",
         guests: "Show guests",
         show_deactivated: "Show deactivated users",
+        show_locked: "Show locked users",
         user_id: "Search user",
         displayname: "Displayname",
         password: "Password",

--- a/src/i18n/index.d.ts
+++ b/src/i18n/index.d.ts
@@ -120,6 +120,7 @@ interface SynapseTranslationMessages extends TranslationMessages {
         erased?: string; // TODO: fa, fr, it, zh
         guests: string;
         show_deactivated: string;
+        show_locked?: string // TODO: de, fa, fr, it, zh
         user_id: string;
         displayname: string;
         password: string;

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -90,6 +90,7 @@ const userFilters = [
   <SearchInput source="name" alwaysOn />,
   <BooleanInput source="guests" alwaysOn />,
   <BooleanInput label="resources.users.fields.show_deactivated" source="deactivated" alwaysOn />,
+  <BooleanInput label="resources.users.fields.show_locked" source="locked" alwaysOn />,
 ];
 
 const UserBulkActionButtons = () => (
@@ -107,7 +108,7 @@ export const UserList = (props: ListProps) => (
   <List
     {...props}
     filters={userFilters}
-    filterDefaultValues={{ guests: true, deactivated: false }}
+    filterDefaultValues={{ guests: true, deactivated: false, locked: false }}
     sort={{ field: "name", order: "ASC" }}
     actions={<UserListActions />}
     pagination={<UserPagination />}

--- a/src/synapse/dataProvider.ts
+++ b/src/synapse/dataProvider.ts
@@ -489,7 +489,7 @@ function getSearchOrder(order: "ASC" | "DESC") {
 const dataProvider: SynapseDataProvider = {
   getList: async (resource, params) => {
     console.log("getList " + resource);
-    const { user_id, name, guests, deactivated, search_term, destination, valid } = params.filter;
+    const { user_id, name, guests, deactivated, locked, search_term, destination, valid } = params.filter;
     const { page, perPage } = params.pagination;
     const { field, order } = params.sort;
     const from = (page - 1) * perPage;
@@ -502,6 +502,7 @@ const dataProvider: SynapseDataProvider = {
       destination: destination,
       guests: guests,
       deactivated: deactivated,
+      locked: locked,
       valid: valid,
       order_by: field,
       dir: getSearchOrder(order),


### PR DESCRIPTION
Added a switch, along the same lines of "Show deactivated users", but for the newly added "locked" functionality.

This pull request builds on the recent addition of being able to lock a specific user (added in: https://github.com/Awesome-Technologies/synapse-admin/commit/b5ca951b323b4eeb3d6b901980264aca86c0050e), so that the list of users displayed can include locked users if desired. Without this switch, once a user is locked, they don't show up in the list of users from that point on.