### PR TITLE
Fix a few undefined records

### DIFF
--- a/src/resources/destinations.tsx
+++ b/src/resources/destinations.tsx
@@ -87,7 +87,7 @@ const DestinationTitle = () => {
   const translate = useTranslate();
   return (
     <span>
-      {translate("resources.destinations.name", 1)} {record.destination}
+      {translate("resources.destinations.name", 1)} {record?.destination}
     </span>
   );
 };

--- a/src/resources/rooms.tsx
+++ b/src/resources/rooms.tsx
@@ -65,7 +65,7 @@ const RoomTitle = () => {
 
 const RoomShowActions = () => {
   const record = useRecordContext();
-  const publishButton = record.public ? <RoomDirectoryUnpublishButton /> : <RoomDirectoryPublishButton />;
+  const publishButton = record?.public ? <RoomDirectoryUnpublishButton /> : <RoomDirectoryPublishButton />;
   // FIXME: refresh after (un)publish
   return (
     <TopToolbar>

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -140,7 +140,7 @@ const UserEditActions = () => {
 
   return (
     <TopToolbar>
-      {!record.deactivated && <ServerNoticeButton />}
+      {!record?.deactivated && <ServerNoticeButton />}
       <DeleteButton
         label="resources.users.action.erase"
         confirmTitle={translate("resources.users.helper.erase", {


### PR DESCRIPTION
Fix several cases of `record` being undefined during the initial render. Happens if a user/room/federation details are open and the user presses F5, doesn't happen during normal navigation.