### PR TITLE
Federation page improvements

### DIFF
--- a/src/resources/destinations.tsx
+++ b/src/resources/destinations.tsx
@@ -27,6 +27,7 @@ import {
   useNotify,
   useRefresh,
   useTranslate,
+  DateFieldProps,
 } from "react-admin";
 
 import { DATE_FORMAT } from "../components/date";
@@ -92,6 +93,14 @@ const DestinationTitle = () => {
   );
 };
 
+const RetryDateField = (props: DateFieldProps) => {
+  const record = useRecordContext(props);
+  if (props.source && get(record, props.source) === 0) {
+    return <DateField {...props} record={{...record, [props.source]: null}} />
+  }
+  return <DateField {...props} />
+}
+
 export const DestinationList = (props: ListProps) => {
   return (
     <List
@@ -103,7 +112,7 @@ export const DestinationList = (props: ListProps) => {
       <Datagrid rowSx={destinationRowSx} rowClick={id => `${id}/show/rooms`} bulkActionButtons={false}>
         <TextField source="destination" />
         <DateField source="failure_ts" showTime options={DATE_FORMAT} />
-        <DateField source="retry_last_ts" showTime options={DATE_FORMAT} />
+        <RetryDateField source="retry_last_ts" showTime options={DATE_FORMAT} />
         <TextField source="retry_interval" />
         <TextField source="last_successful_stream_ordering" />
         <DestinationReconnectButton />

--- a/src/resources/destinations.tsx
+++ b/src/resources/destinations.tsx
@@ -1,9 +1,11 @@
+import { get } from "lodash";
 import { MouseEvent } from "react";
 
 import AutorenewIcon from "@mui/icons-material/Autorenew";
 import DestinationsIcon from "@mui/icons-material/CloudQueue";
 import FolderSharedIcon from "@mui/icons-material/FolderShared";
 import ViewListIcon from "@mui/icons-material/ViewList";
+import { blue } from "@mui/material/colors";
 import {
   Button,
   Datagrid,
@@ -31,12 +33,9 @@ import {
 } from "react-admin";
 
 import { DATE_FORMAT } from "../components/date";
+import { lighten, useTheme } from '@mui/material';
 
 const DestinationPagination = () => <Pagination rowsPerPageOptions={[10, 25, 50, 100, 500, 1000]} />;
-
-const destinationRowSx = (record: RaRecord) => ({
-  backgroundColor: record.retry_last_ts > 0 ? "#ffcccc" : "white",
-});
 
 const destinationFilters = [<SearchInput source="destination" alwaysOn />];
 
@@ -96,12 +95,22 @@ const DestinationTitle = () => {
 const RetryDateField = (props: DateFieldProps) => {
   const record = useRecordContext(props);
   if (props.source && get(record, props.source) === 0) {
-    return <DateField {...props} record={{...record, [props.source]: null}} />
+    return <DateField {...props} record={{ ...record, [props.source]: null }} />;
   }
-  return <DateField {...props} />
-}
+  return <DateField {...props} />;
+};
 
 export const DestinationList = (props: ListProps) => {
+  const { palette: { error, mode }, } = useTheme();
+  const destinationRowSx = (record: RaRecord) => ({
+    backgroundColor: record.retry_last_ts > 0 ? lighten(error[mode], 0.5) : undefined,
+    "& > td": mode === 'dark' ? {
+      color: record.retry_last_ts > 0 ? "black" : "white",
+      "& > button": {
+        color: blue[700],
+      },
+   } : undefined,
+  });
   return (
     <List
       {...props}


### PR DESCRIPTION
This PR hides zero last retry timestamps that are displayed as 1970/01/01 00:00:00 (misleading) and also improves the dark theme. Without this patch the white rows also have white text in them so the text is invisible unless you point at them, pink rows also have white text that's hard to read, and the reconnect button's color is too bright.