### PR TITLE
Add identifier when login with password

### DIFF
--- a/src/synapse/authProvider.test.ts
+++ b/src/synapse/authProvider.test.ts
@@ -29,7 +29,17 @@ describe("authProvider", () => {
 
       expect(ret).toBe(undefined);
       expect(fetch).toBeCalledWith("http://example.com/_matrix/client/r0/login", {
-        body: '{"device_id":null,"initial_device_display_name":"Synapse Admin","type":"m.login.password","user":"@user:example.com","password":"secret"}',
+        body: JSON.stringify({
+          device_id: null,
+          initial_device_display_name: "Synapse Admin",
+          type: "m.login.password",
+          user: "@user:example.com",
+          password: "secret",
+          identifier: {
+            type: "m.id.user",
+            user: "@user:example.com",
+          }
+        }),
         headers: new Headers({
           Accept: "application/json",
           "Content-Type": "application/json",

--- a/src/synapse/authProvider.ts
+++ b/src/synapse/authProvider.ts
@@ -31,6 +31,10 @@ const authProvider: AuthProvider = {
                 type: "m.login.password",
                 user: username,
                 password: password,
+                identifier: {
+                  type: "m.id.user",
+                  user: username,
+                },
               }
         )
       ),


### PR DESCRIPTION
It is a duplicate to #497

I needed it, that is why this PR without conflicts.

> Since Matrix spec v1, the username when login with password should be sent in the `identifier` field, as explained here: https://spec.matrix.org/v1.1/client-server-api/#matrix-user-id
>
>A full example of a password based login payload can be found here: https://spec.matrix.org/v1.1/client-server-api/#password-based