### PR TITLE
fix: show user default tab and after creation

### DIFF
--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -159,7 +159,7 @@ const UserEditActions = () => {
 export const UserCreate = (props: CreateProps) => (
   <Create
     {...props}
-    redirect={(resource: string, id: Identifier) => {
+    redirect={(resource: string | undefined, id: Identifier | undefined) => {
       return `${resource}/${id}`;
     }}
   >

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -47,6 +47,7 @@ import {
   TopToolbar,
   NumberField,
   useListContext,
+  Identifier,
 } from "react-admin";
 import { Link } from "react-router-dom";
 
@@ -112,7 +113,10 @@ export const UserList = (props: ListProps) => (
     actions={<UserListActions />}
     pagination={<UserPagination />}
   >
-    <Datagrid rowClick="edit" bulkActionButtons={<UserBulkActionButtons />}>
+    <Datagrid
+      rowClick={(id: Identifier, resource: string) => `/${resource}/${id}`}
+      bulkActionButtons={<UserBulkActionButtons />}
+    >
       <AvatarField source="avatar_src" sx={{ height: "40px", width: "40px" }} sortBy="avatar_url" />
       <TextField source="id" sortBy="name" />
       <TextField source="displayname" />
@@ -153,7 +157,12 @@ const UserEditActions = () => {
 };
 
 export const UserCreate = (props: CreateProps) => (
-  <Create {...props}>
+  <Create
+    {...props}
+    redirect={(resource: string, id: Identifier) => {
+      return `${resource}/${id}`;
+    }}
+  >
     <SimpleForm>
       <TextInput source="id" autoComplete="off" validate={validateUser} />
       <TextInput source="displayname" validate={maxLength(256)} />


### PR DESCRIPTION
Related / adapted from:

- https://github.com/etkecc/synapse-admin/pull/8

> fixes an annoying problem that when you click on a User form the List, the first (Default) tab doesn't show any data

- https://github.com/etkecc/synapse-admin/pull/16

> fix the user's default tab after creating a new user
> 
> Steps to reproduce:
> 
> 1. Open Users list, click on Create button (/#/users/create)
> 2. Enter user details and click on Save button
> 3. Observe broken default user tab with url encoded hash (/#/users/%40localpart%3Aexample.com), page reload does not help
> 4. Click on the User tab name, and observe working default user tab with not url encoded hash (/#/users/@localpart:example.com)
>
> So, it looks like the problem is with url-encoded hash params