### PR TITLE
Add permissions to ghpages workflow

### DIFF
--- a/.github/workflows/edge_ghpage.yml
+++ b/.github/workflows/edge_ghpage.yml
@@ -1,4 +1,7 @@
 name: Build and Deploy Edge version to GH Pages
+permissions:
+  contents: read
+  pages: write
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Awesome-Technologies/synapse-admin/security/code-scanning/7](https://github.com/Awesome-Technologies/synapse-admin/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the actions used in the workflow:
- `actions/checkout` and `actions/setup-node` require `contents: read` to access the repository code.
- `JamesIves/github-pages-deploy-action` requires `pages: write` to deploy the built files to GitHub Pages.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
