### PR TITLE
fix(Dockerfile): `FROM` and `AS` both in uppercase, `FromAsCasing`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM node:lts as builder
+FROM node:lts AS builder
 LABEL org.opencontainers.image.url=https://github.com/Awesome-Technologies/synapse-admin org.opencontainers.image.source=https://github.com/Awesome-Technologies/synapse-admin
 # Base path for synapse admin
 ARG BASE_PATH=./


### PR DESCRIPTION
There ist a warning.

```txt
[Build and Push Tag: Dockerfile#L2](https://github.com/Awesome-Technologies/synapse-admin/commit/ef8ae9b38fbd7c39c5c1274a00fe4826789de140#annotation_35203733669)
FromAsCasing: 'as' and 'FROM' keywords' casing do not match More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
```

CI: https://github.com/Awesome-Technologies/synapse-admin/actions/runs/15341176943/job/43167494813