### PR TITLE
misc: increase `build.chunkSizeWarningLimit`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   base: "./",
+  build: {
+    chunkSizeWarningLimit: 1500,
+  },
   plugins: [
     react(),
     vitePluginVersionMark({


### PR DESCRIPTION
Suppress build warning:

```
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
```
