### PR TITLE
ci: bump NodeJs to v22 (LTS)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
       - name: Install dependencies
         run: yarn --immutable
       - name: Run checks

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,28 @@
+name: Create release tarball and attach to tag
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "22"
+      - run: yarn install
+      - run: yarn build
+      - run: |
+          version=`git describe --dirty --tags || echo unknown`
+          mkdir -p dist
+          cp -r build synapse-admin-$version
+          tar chvzf dist/synapse-admin-$version.tar.gz synapse-admin-$version
+      - uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf
+        with:
+          files: dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- NodeJS v18 is EoL: https://endoflife.date/nodejs
- Docker `node:lts-alpine` (from `Dockerfile`) uses v22 https://hub.docker.com/layers/library/node/lts-alpine/images/sha256-11d923cca2138d844282dc0c333132bba72deb913d635c3c33e54523b455a4da