### PR TITLE
fix: volumes must be list in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ services:
   synapse-admin:
     ...
     volumes:
-      ./config.json:/app/config.json:ro
+      - ./config.json:/app/config.json:ro
     ...
 ```
 


### PR DESCRIPTION
The current volumes example would generate this error on `docker compose up`:
```
validating /opt/.../docker-compose.yml: services.synapse-admin.volumes must be a list
```