### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ services:
   synapse-admin:
     ...
     volumes:
-      ./config.json:/app/config.json:ro
+      - ./config.json:/app/config.json:ro
     ...
 ```
 


### PR DESCRIPTION
Documentation for injecting config.json was mis-formatted.  If used as-is, docker compose gives an error: `synapse-admin/docker-compose.yml: services.synapse-admin.volumes must be a list`

With this fix, that error goes away.