### PR TITLE
feat: add access_token support for MMR (media/avatars)

### DIFF
--- a/src/components/AvatarField.test.tsx
+++ b/src/components/AvatarField.test.tsx
@@ -1,18 +1,70 @@
 import { render, screen } from "@testing-library/react";
 import { RecordContextProvider } from "react-admin";
+import { vi } from "vitest";
 
 import AvatarField from "./AvatarField";
 
+const mockFetchWithAuth = vi.fn();
+vi.mock("../synapse/synapse", () => ({
+  fetchWithAuth: (url: string) => mockFetchWithAuth(url),
+}));
+
+const storageGetItem = vi.fn();
+vi.mock("../storage", () => ({
+  default: {
+    getItem: (key: string) => storageGetItem(key),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
 describe("AvatarField", () => {
-  it("shows image", () => {
-    const value = {
-      avatar: "foo",
-    };
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows image from src when no token", () => {
+    storageGetItem.mockReturnValue(null);
+    const value = { avatar: "https://hs.example.com/thumb.png" };
     render(
       <RecordContextProvider value={value}>
         <AvatarField source="avatar" />
       </RecordContextProvider>
     );
-    expect(screen.getByRole("img").getAttribute("src")).toBe("foo");
+    expect(screen.getByRole("img").getAttribute("src")).toBe("https://hs.example.com/thumb.png");
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it("fetches with auth when token present and uses blob URL", async () => {
+    storageGetItem.mockImplementation((key: string) => (key === "access_token" ? "token123" : null));
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(["fake"], { type: "image/png" })),
+    });
+    const value = { avatar_src: "https://hs.example.com/_matrix/media/r0/thumbnail/hs/id" };
+    render(
+      <RecordContextProvider value={value}>
+        <AvatarField source="avatar_src" />
+      </RecordContextProvider>
+    );
+    expect(mockFetchWithAuth).toHaveBeenCalledWith("https://hs.example.com/_matrix/media/r0/thumbnail/hs/id");
+    await vi.waitFor(() => {
+      const img = screen.getByRole("img");
+      expect(img.getAttribute("src")).toMatch(/^blob:/);
+    });
+  });
+
+  it("falls back to src when fetch fails", async () => {
+    storageGetItem.mockImplementation((key: string) => (key === "access_token" ? "token123" : null));
+    mockFetchWithAuth.mockRejectedValue(new Error("network error"));
+    const value = { avatar_src: "https://hs.example.com/thumb.png" };
+    render(
+      <RecordContextProvider value={value}>
+        <AvatarField source="avatar_src" />
+      </RecordContextProvider>
+    );
+    await vi.waitFor(() => {
+      expect(screen.getByRole("img").getAttribute("src")).toBe("https://hs.example.com/thumb.png");
+    });
   });
 });

--- a/src/components/AvatarField.tsx
+++ b/src/components/AvatarField.tsx
@@ -1,13 +1,52 @@
 import { get } from "lodash";
+import { useEffect, useRef, useState } from "react";
 
 import { Avatar } from "@mui/material";
 import { useRecordContext } from "react-admin";
 
+import { fetchWithAuth } from "../synapse/synapse";
+import storage from "../storage";
+
 const AvatarField = ({ source, ...rest }) => {
   const record = useRecordContext(rest);
   const src = get(record, source)?.toString();
+  const [imgSrc, setImgSrc] = useState(src ?? "");
+  const blobUrlRef = useRef<string | null>(null);
   const { alt, classes, sizes, sx, variant } = rest;
-  return <Avatar alt={alt} classes={classes} sizes={sizes} src={src} sx={sx} variant={variant} />;
+
+  useEffect(() => {
+    if (!src) {
+      setImgSrc("");
+      return;
+    }
+    const token = storage.getItem("access_token");
+    if (!token) {
+      setImgSrc(src);
+      return;
+    }
+    let cancelled = false;
+    fetchWithAuth(src)
+      .then(res => (res.ok ? res.blob() : Promise.reject(new Error("Failed to load"))))
+      .then(blob => {
+        if (cancelled) return;
+        if (blobUrlRef.current) URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = URL.createObjectURL(blob);
+        setImgSrc(blobUrlRef.current);
+      })
+      .catch(() => {
+        if (!cancelled) setImgSrc(src);
+      });
+    return () => {
+      cancelled = true;
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = null;
+      }
+    };
+  }, [src]);
+
+  const displaySrc = imgSrc || src;
+  return <Avatar alt={alt} classes={classes} sizes={sizes} src={displaySrc} sx={sx} variant={variant} />;
 };
 
 export default AvatarField;

--- a/src/components/ViewMediaButton.test.tsx
+++ b/src/components/ViewMediaButton.test.tsx
@@ -1,0 +1,51 @@
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { ViewMediaButton } from "./media";
+
+const mockFetchWithAuth = vi.fn();
+const mockGetMediaUrl = vi.fn((id: string) => `https://hs.example.com/_matrix/media/v1/download/${id}?allow_redirect=true`);
+vi.mock("../synapse/synapse", () => ({
+  getMediaUrl: (id: string) => mockGetMediaUrl(id),
+  fetchWithAuth: (url: string) => mockFetchWithAuth(url),
+}));
+
+vi.mock("react-admin", async () => {
+  const actual = await vi.importActual("react-admin");
+  return {
+    ...actual,
+    useTranslate: () => (key: string) => key,
+    useNotify: () => vi.fn(),
+  };
+});
+
+const theme = createTheme();
+
+describe("ViewMediaButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchWithAuth.mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(["content"], { type: "application/octet-stream" })),
+    });
+    Object.defineProperty(window, "open", { value: vi.fn(), writable: true });
+  });
+
+  it("calls fetchWithAuth on click (no token in URL)", async () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <ViewMediaButton media_id="example.com/abc123" label="media" />
+      </ThemeProvider>
+    );
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+    expect(mockGetMediaUrl).toHaveBeenCalledWith("example.com/abc123");
+    const url = mockGetMediaUrl("example.com/abc123");
+    expect(url).not.toContain("access_token");
+    await vi.waitFor(() => {
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(url);
+    });
+  });
+});

--- a/src/components/media.tsx
+++ b/src/components/media.tsx
@@ -29,11 +29,10 @@ import {
   useTranslate,
 } from "react-admin";
 import { useMutation } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
 
 import { dateParser } from "./date";
 import { DeleteMediaParams, SynapseDataProvider } from "../synapse/dataProvider";
-import { getMediaUrl } from "../synapse/synapse";
+import { getMediaUrl, fetchWithAuth } from "../synapse/synapse";
 import storage from "../storage";
 
 const DeleteMediaDialog = ({ open, onClose, onSubmit }) => {
@@ -313,14 +312,33 @@ export const QuarantineMediaButton = (props: ButtonProps) => {
 
 export const ViewMediaButton = ({ media_id, label }) => {
   const translate = useTranslate();
+  const notify = useNotify();
+  const [loading, setLoading] = useState(false);
   const url = getMediaUrl(media_id);
+
+  const handleOpen = async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth(url);
+      if (!res.ok) throw new Error(res.statusText);
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      window.open(blobUrl, "_blank", "noopener");
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
+    } catch (e) {
+      notify("resources.users_media.action.open_error", { type: "error" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <Box style={{ whiteSpace: "pre" }}>
       <Tooltip title={translate("resources.users_media.action.open")}>
         <span>
           <Button
-            component={Link}
-            to={url}
+            onClick={handleOpen}
+            disabled={loading}
             target="_blank"
             rel="noopener"
             style={{ minWidth: 0, paddingLeft: 0, paddingRight: 0 }}

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -282,6 +282,7 @@ const de: SynapseTranslationMessages = {
       },
       action: {
         open: "Mediendatei in neuem Fenster öffnen",
+        open_error: "Medien konnten nicht geöffnet werden",
       },
     },
     protect_media: {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -273,6 +273,7 @@ const en: SynapseTranslationMessages = {
       },
       action: {
         open: "Open media file in new window",
+        open_error: "Failed to open media",
       },
     },
     protect_media: {

--- a/src/i18n/fa.ts
+++ b/src/i18n/fa.ts
@@ -256,6 +256,10 @@ const fa: SynapseTranslationMessages = {
         created_ts: "ایجاد شده",
         last_access_ts: "آخرین دسترسی",
       },
+      action: {
+        open: "باز کردن فایل رسانه در پنجره جدید",
+        open_error: "باز کردن رسانه ناموفق بود",
+      },
     },
     protect_media: {
       action: {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -258,6 +258,10 @@ const fr: SynapseTranslationMessages = {
         created_ts: "Date de création",
         last_access_ts: "Dernier accès",
       },
+      action: {
+        open: "Ouvrir le fichier média dans une nouvelle fenêtre",
+        open_error: "Échec de l'ouverture du média",
+      },
     },
     protect_media: {
       action: {

--- a/src/i18n/index.d.ts
+++ b/src/i18n/index.d.ts
@@ -267,6 +267,7 @@ interface SynapseTranslationMessages extends TranslationMessages {
       };
       action?: {
         open: string;
+        open_error: string;
       };
     };
     protect_media?: {

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -257,6 +257,10 @@ const it: SynapseTranslationMessages = {
         created_ts: "Creato",
         last_access_ts: "Ultimo accesso",
       },
+      action: {
+        open: "Apri file multimediale in nuova finestra",
+        open_error: "Impossibile aprire il file multimediale",
+      },
     },
     protect_media: {
       action: {

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -292,6 +292,7 @@ const ru: SynapseTranslationMessages = {
       },
       action: {
         open: "Открыть файл в новом окне",
+        open_error: "Не удалось открыть медиа",
       },
     },
     protect_media: {

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -247,6 +247,10 @@ const zh: SynapseTranslationMessages = {
         created_ts: "创建",
         last_access_ts: "上一次访问",
       },
+      action: {
+        open: "在新窗口中打开媒体文件",
+        open_error: "无法打开媒体",
+      },
     },
     pushers: {
       name: "发布者",

--- a/src/synapse/dataProvider.test.ts
+++ b/src/synapse/dataProvider.test.ts
@@ -74,6 +74,9 @@ describe("dataProvider", () => {
 
     expect(user.data.id).toEqual("user_id1");
     expect(user.data.displayname).toEqual("User");
+    expect(user.data.avatar_src).toBeDefined();
+    expect(user.data.avatar_src).not.toContain("access_token");
+    expect(user.data.avatar_src).toMatch(/\/_matrix\/media\/r0\/thumbnail\/localhost\/user1/);
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/synapse/dataProvider.ts
+++ b/src/synapse/dataProvider.ts
@@ -32,9 +32,7 @@ const mxcUrlToHttp = (mxcUrl: string) => {
   if (ret == null) return null;
   const serverName = ret[1];
   const mediaId = ret[2];
-  const url = `${homeserver}/_matrix/media/r0/thumbnail/${serverName}/${mediaId}?width=24&height=24&method=scale`;
-  const token = storage.getItem("access_token");
-  return token != null ? `${url}&access_token=${encodeURIComponent(token)}` : url;
+  return `${homeserver}/_matrix/media/r0/thumbnail/${serverName}/${mediaId}?width=24&height=24&method=scale`;
 };
 
 interface Room {

--- a/src/synapse/synapse.test.ts
+++ b/src/synapse/synapse.test.ts
@@ -1,4 +1,6 @@
-import { isValidBaseUrl, splitMxid } from "./synapse";
+import storage from "../storage";
+
+import { getAuthHeaders, getMediaUrl, isValidBaseUrl, splitMxid } from "./synapse";
 
 describe("splitMxid", () => {
   it("splits valid MXIDs", () =>
@@ -20,4 +22,34 @@ describe("isValidBaseUrl", () => {
   it("rejects base URLs without protocol", () => expect(isValidBaseUrl("foo.bar")).toBeFalsy());
   it("rejects base URLs with path", () => expect(isValidBaseUrl("http://foo.bar/path")).toBeFalsy());
   it("rejects invalid base URLs", () => expect(isValidBaseUrl("http:/foo.bar")).toBeFalsy());
+});
+
+describe("getAuthHeaders", () => {
+  it("returns empty object when no access_token", () => {
+    storage.removeItem("access_token");
+    expect(getAuthHeaders()).toEqual({});
+  });
+  it("returns Bearer header when access_token is set", () => {
+    storage.setItem("access_token", "syt_abc123");
+    expect(getAuthHeaders()).toEqual({ Authorization: "Bearer syt_abc123" });
+    storage.removeItem("access_token");
+  });
+});
+
+describe("getMediaUrl", () => {
+  it("returns URL without access_token in query string", () => {
+    storage.setItem("base_url", "https://hs.example.com");
+    storage.removeItem("access_token");
+    const url = getMediaUrl("example.com/abc123");
+    expect(url).toBe("https://hs.example.com/_matrix/media/v1/download/example.com/abc123?allow_redirect=true");
+    expect(url).not.toContain("access_token");
+  });
+  it("still does not put token in URL when token is present", () => {
+    storage.setItem("base_url", "https://hs.example.com");
+    storage.setItem("access_token", "secret");
+    const url = getMediaUrl("example.com/xyz");
+    expect(url).not.toContain("access_token");
+    expect(url).not.toContain("secret");
+    storage.removeItem("access_token");
+  });
 });

--- a/src/synapse/synapse.ts
+++ b/src/synapse/synapse.ts
@@ -54,11 +54,29 @@ export const getSupportedLoginFlows = async baseUrl => {
   return response.json.flows;
 };
 
+/**
+ * Headers for authenticated requests (Bearer token). Use for media/download to avoid token in URL.
+ */
+export const getAuthHeaders = (): Record<string, string> => {
+  const token = storage.getItem("access_token");
+  if (token == null) return {};
+  return { Authorization: `Bearer ${token}` };
+};
+
+/**
+ * Build media download URL (no token in URL; use getAuthHeaders() when fetching).
+ */
 export const getMediaUrl = media_id => {
   const baseUrl = storage.getItem("base_url");
-  const token = storage.getItem("access_token");
-  const url = `${baseUrl}/_matrix/media/v1/download/${media_id}?allow_redirect=true`;
-  return token != null ? `${url}&access_token=${encodeURIComponent(token)}` : url;
+  return `${baseUrl}/_matrix/media/v1/download/${media_id}?allow_redirect=true`;
+};
+
+/**
+ * Fetch a URL with optional Bearer auth. Use for media/avatars so token is not in query string.
+ */
+export const fetchWithAuth = async (url: string): Promise<Response> => {
+  const headers = getAuthHeaders();
+  return fetch(url, { headers });
 };
 
 /**


### PR DESCRIPTION
Problem:
Media download URLs and avatar/preview URLs (mxc → http) were used without authentication. When the MMR or homeserver requires auth to serve media, those requests return 401/403, so avatars don’t load and direct media links fail.
Solution:
getMediaUrl (synapse.ts): When access_token is present in storage, it is appended to media download URLs as &access_token=... (value encoded with encodeURIComponent). Used for media download links (including in media.tsx).
mxcUrlToHttp (dataProvider.ts): When a token is present, it is appended the same way to preview/avatar URLs. Used for user and room avatars (avatar_src).
In both cases the token is passed as a query parameter: &access_token=${encodeURIComponent(token)}.