### PR TITLE
fix: clear stale device_id on logout and retry login without it when revoked

### DIFF
--- a/src/synapse/authProvider.test.ts
+++ b/src/synapse/authProvider.test.ts
@@ -35,7 +35,7 @@ describe("authProvider", () => {
           identifier: {
             type: "m.id.user",
             user: "@user:example.com",
-          }
+          },
         }),
         headers: new Headers({
           Accept: "application/json",
@@ -80,10 +80,107 @@ describe("authProvider", () => {
     expect(storage.getItem("device_id")).toEqual("some_device");
   });
 
+  describe("login with stale device_id", () => {
+    it("should retry login without device_id when the first attempt fails", async () => {
+      // A stale device_id is present from a previous session that was
+      // externally revoked (e.g. via Element "Remove Device").
+      storage.setItem("device_id", "REVOKED_DEVICE");
+
+      // First call with the stale device_id fails.
+      fetchMock.mockRejectOnce(new Error("M_UNKNOWN_DEVICE"));
+
+      // Second call without device_id succeeds.
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          home_server: "example.com",
+          user_id: "@user:example.com",
+          access_token: "fresh_token",
+          device_id: "NEW_DEVICE",
+        })
+      );
+
+      await authProvider.login({
+        base_url: "http://example.com",
+        username: "@user:example.com",
+        password: "secret",
+      });
+
+      // The first call should include the stale device_id.
+      expect(fetch).toHaveBeenCalledTimes(2);
+      const firstBody = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+      expect(firstBody.device_id).toBe("REVOKED_DEVICE");
+
+      // The retry should use null device_id.
+      const secondBody = JSON.parse(fetchMock.mock.calls[1][1]!.body as string);
+      expect(secondBody.device_id).toBeNull();
+
+      // Storage should reflect the fresh session.
+      expect(storage.getItem("access_token")).toBe("fresh_token");
+      expect(storage.getItem("device_id")).toBe("NEW_DEVICE");
+    });
+
+    it("should clear stale device_id from storage after retry", async () => {
+      storage.setItem("device_id", "STALE_DEVICE");
+
+      fetchMock.mockRejectOnce(new Error("M_UNKNOWN_DEVICE"));
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          home_server: "example.com",
+          user_id: "@user:example.com",
+          access_token: "new_token",
+          device_id: "FRESH_DEVICE",
+        })
+      );
+
+      await authProvider.login({
+        base_url: "http://example.com",
+        username: "@user:example.com",
+        password: "secret",
+      });
+
+      // The stale device_id should have been removed before the retry and
+      // replaced by the new one from the server response.
+      expect(storage.getItem("device_id")).toBe("FRESH_DEVICE");
+    });
+
+    it("should propagate the error when login fails without a stored device_id", async () => {
+      // No stored device_id — there is nothing to retry with.
+      fetchMock.mockRejectOnce(new Error("M_FORBIDDEN"));
+
+      await expect(
+        authProvider.login({
+          base_url: "http://example.com",
+          username: "@user:example.com",
+          password: "wrong",
+        })
+      ).rejects.toThrow("M_FORBIDDEN");
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should propagate the error when both login attempts fail", async () => {
+      storage.setItem("device_id", "STALE");
+
+      fetchMock.mockRejectOnce(new Error("first failure"));
+      fetchMock.mockRejectOnce(new Error("second failure"));
+
+      await expect(
+        authProvider.login({
+          base_url: "http://example.com",
+          username: "@user:example.com",
+          password: "wrong",
+        })
+      ).rejects.toThrow("second failure");
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("logout", () => {
-    it("should remove the access_token from storage", async () => {
+    it("should remove the access_token and device_id from storage", async () => {
       storage.setItem("base_url", "example.com");
       storage.setItem("access_token", "foo");
+      storage.setItem("device_id", "some_device");
       fetchMock.mockResponse(JSON.stringify({}));
 
       await authProvider.logout(null);
@@ -97,6 +194,7 @@ describe("authProvider", () => {
         user: { authenticated: true, token: "Bearer foo" },
       });
       expect(storage.getItem("access_token")).toBeNull();
+      expect(storage.getItem("device_id")).toBeNull();
     });
   });
 

--- a/src/synapse/authProvider.ts
+++ b/src/synapse/authProvider.ts
@@ -27,48 +27,75 @@ const getStoredIdentity = () => {
   };
 };
 
+/** Build the login request body for a given device_id and credential set. */
+const buildLoginBody = (
+  deviceId: string | null,
+  loginToken: string | null | undefined,
+  username: string | null | undefined,
+  password: string | null | undefined
+): string =>
+  JSON.stringify(
+    Object.assign(
+      {
+        device_id: deviceId,
+        initial_device_display_name: "Synapse Admin",
+      },
+      loginToken
+        ? {
+            type: "m.login.token",
+            token: loginToken,
+          }
+        : {
+            type: "m.login.password",
+            user: username,
+            password: password,
+            identifier: {
+              type: "m.id.user",
+              user: username,
+            },
+          }
+    )
+  );
+
 /** React-admin auth provider backed by Synapse password login and token-based SSO callbacks. */
 const authProvider: AuthProvider = {
   /** Exchange credentials for an access token and persist the resulting session locally. */
-  login: async ({
-    base_url,
-    username,
-    password,
-    loginToken,
-  }: LoginParams) => {
-    const options: Options = {
-      method: "POST",
-      body: JSON.stringify(
-        Object.assign(
-          {
-            device_id: storage.getItem("device_id"),
-            initial_device_display_name: "Synapse Admin",
-          },
-          loginToken
-            ? {
-                type: "m.login.token",
-                token: loginToken,
-              }
-            : {
-                type: "m.login.password",
-                user: username,
-                password: password,
-                identifier: {
-                  type: "m.id.user",
-                  user: username,
-                },
-              }
-        )
-      ),
-    };
-
+  login: async ({ base_url, username, password, loginToken }: LoginParams) => {
     // use the base_url from login instead of the well_known entry from the
     // server, since the admin might want to access the admin API via some
     // private address
     const normalizedBaseUrl = normalizeBaseUrl(base_url);
     storage.setItem("base_url", normalizedBaseUrl);
 
-    const { json } = await fetchJson(buildUrl(normalizedBaseUrl, "/_matrix/client/r0/login"), options);
+    const loginUrl = buildUrl(normalizedBaseUrl, "/_matrix/client/r0/login");
+    const storedDeviceId = storage.getItem("device_id");
+
+    let json: Record<string, string>;
+
+    // When a stored device_id exists, the server may reject the login if the
+    // device was externally revoked (e.g. via Element "Remove Device").  In
+    // that case, retry without the stale device_id so the server assigns a
+    // fresh one.  See https://github.com/Awesome-Technologies/synapse-admin/issues/757
+    if (storedDeviceId) {
+      try {
+        ({ json } = await fetchJson(loginUrl, {
+          method: "POST",
+          body: buildLoginBody(storedDeviceId, loginToken, username, password),
+        }));
+      } catch {
+        storage.removeItem("device_id");
+        ({ json } = await fetchJson(loginUrl, {
+          method: "POST",
+          body: buildLoginBody(null, loginToken, username, password),
+        }));
+      }
+    } else {
+      ({ json } = await fetchJson(loginUrl, {
+        method: "POST",
+        body: buildLoginBody(null, loginToken, username, password),
+      }));
+    }
+
     storage.setItem("home_server", json.home_server);
     storage.setItem("user_id", json.user_id);
     storage.setItem("access_token", json.access_token);
@@ -91,7 +118,8 @@ const authProvider: AuthProvider = {
     clearStoredAuth();
   },
   /** Treat 401/403 responses as an expired or invalid session. */
-  checkError: ({ status }: { status: number }) => ((status === 401 || status === 403) ? Promise.reject() : Promise.resolve()),
+  checkError: ({ status }: { status: number }) =>
+    status === 401 || status === 403 ? Promise.reject() : Promise.resolve(),
   /** Guard protected routes by checking whether a session token is cached locally. */
   checkAuth: async () => (hasAccessToken() ? Promise.resolve() : Promise.reject()),
   /** Synapse Admin currently does not model separate permission payloads. */

--- a/src/synapse/synapse.test.ts
+++ b/src/synapse/synapse.test.ts
@@ -45,7 +45,6 @@ describe("isValidBaseUrl", () => {
   it("rejects invalid base URLs", () => expect(isValidBaseUrl("http:/foo.bar")).toBeFalsy());
 });
 
-
 describe("synapse helpers", () => {
   beforeEach(() => {
     storage.clear();
@@ -55,7 +54,9 @@ describe("synapse helpers", () => {
 
   it("normalizes and builds homeserver URLs", () => {
     expect(normalizeBaseUrl("https%3A%2F%2Fmatrix.example.com///")).toBe("https://matrix.example.com");
-    expect(buildUrl("https://matrix.example.com/", "/_matrix/client")).toBe("https://matrix.example.com/_matrix/client");
+    expect(buildUrl("https://matrix.example.com/", "/_matrix/client")).toBe(
+      "https://matrix.example.com/_matrix/client"
+    );
   });
 
   it("reads and requires stored homeserver information", () => {
@@ -92,11 +93,13 @@ describe("synapse helpers", () => {
 
   it("clears stored auth and builds media URLs from storage", () => {
     storage.setItem("access_token", "secret");
+    storage.setItem("device_id", "OLDDEVICE");
     storage.setItem("base_url", "https://matrix.example.com");
 
     clearStoredAuth();
 
     expect(storage.getItem("access_token")).toBeNull();
+    expect(storage.getItem("device_id")).toBeNull();
     expect(getMediaUrl("server/id")).toBe(
       "https://matrix.example.com/_matrix/media/v1/download/server/id?allow_redirect=true"
     );
@@ -124,9 +127,7 @@ describe("synapse helpers", () => {
 
     await expect(getServerVersion("https://matrix.example.com")).resolves.toBe("1.99.0");
     await expect(getSupportedFeatures("https://matrix.example.com")).resolves.toEqual({ versions: ["r0.6.1"] });
-    await expect(getSupportedLoginFlows("https://matrix.example.com")).resolves.toEqual([
-      { type: "m.login.password" },
-    ]);
+    await expect(getSupportedLoginFlows("https://matrix.example.com")).resolves.toEqual([{ type: "m.login.password" }]);
   });
 
   it("generates random ids and passwords from crypto values", () => {

--- a/src/synapse/synapse.ts
+++ b/src/synapse/synapse.ts
@@ -169,6 +169,7 @@ export const fetchJsonWithoutAuth = (baseUrl: string, endpoint: string, options:
 /** Clear credentials that should not survive logout or failed auth recovery. */
 export const clearStoredAuth = (): void => {
   storage.removeItem("access_token");
+  storage.removeItem("device_id");
 };
 
 /**


### PR DESCRIPTION
When a devvice is externally removed (e.g. via Element 'Remove Device'), the device_id persisted in localStorage would poison all subsequent login attempts. The server either rejects the login or issues a token that immediately gets 401/403'd, creating an infinite 'Session has Ended' loop.

Two changes fix this:

1. clearStoredAuth() now removes device_id alongside access_token so stale device identifiers do not survive logout.
2. The login method retries without the stored device_id when the first attempt fails, letting the server assign a fresh one.

Fixes #757 - cheers!